### PR TITLE
Resolves #56 - Default JsonProperty "strict" to true

### DIFF
--- a/lib/Weasel/JsonMarshaller/Config/DoctrineAnnotations/JsonProperty.php
+++ b/lib/Weasel/JsonMarshaller/Config/DoctrineAnnotations/JsonProperty.php
@@ -34,7 +34,7 @@ class JsonProperty extends NoUndeclaredProperties implements IJsonProperty
     /**
      * @var bool
      */
-    public $strict;
+    public $strict = true;
 
     /**
      * @return string


### PR DESCRIPTION
Fix stupid typo. The default was right for the legacy annotations, but not the Doctrine ones.
