### PR TITLE
Extend error handling for non object types passed in encoding.

### DIFF
--- a/lib/Weasel/JsonMarshaller/JsonMapper.php
+++ b/lib/Weasel/JsonMarshaller/JsonMapper.php
@@ -189,6 +189,10 @@ class JsonMapper
      */
     protected function _encodeObject($object, $typeInfo = null, $type = null)
     {
+        if (!is_object($object)) {
+            throw new InvalidTypeException($type, $object);
+        }
+        
         $class = get_class($object);
         if (!$class) {
             throw new InvalidTypeException($type, $object);


### PR DESCRIPTION
It is a pain to analyse wrong behavior on this without throwing a exception in this case.